### PR TITLE
[CAT-223] DesignSystem InputField

### DIFF
--- a/Projects/Shared/DesignSystem/Example/Sources/Component/InputFieldDetailView.swift
+++ b/Projects/Shared/DesignSystem/Example/Sources/Component/InputFieldDetailView.swift
@@ -1,0 +1,48 @@
+//
+//  InputFieldDetailView.swift
+//  DesignSystem
+//
+//  Created by 김지현 on 8/17/24.
+//  Copyright © 2024 PomoNyang. All rights reserved.
+//
+
+import SwiftUI
+
+import DesignSystem
+
+enum ExampleInputFieldError: String, InputFieldErrorProtocol {
+  case one, two, three
+
+  var message: String {
+    return self.rawValue
+  }
+}
+
+struct InputFieldDetailView: View {
+  @State var text: String = ""
+  @State var error: ExampleInputFieldError? = nil
+
+  var body: some View {
+    VStack {
+      Button(title: "random Error") {
+        error = [ExampleInputFieldError.one, ExampleInputFieldError.two, ExampleInputFieldError.three].randomElement()
+      }
+      Button(title: "nil Error") {
+        error = nil
+      }
+
+      InputField<ExampleInputFieldError>(
+        placeholder: "Placeholder",
+        text: $text,
+        fieldError: $error
+      )
+      .padding(.horizontal, 20)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Alias.Color.Background.primary)
+  }
+}
+
+#Preview {
+  InputFieldDetailView()
+}

--- a/Projects/Shared/DesignSystem/Example/Sources/ContentView.swift
+++ b/Projects/Shared/DesignSystem/Example/Sources/ContentView.swift
@@ -77,6 +77,12 @@ struct ContentView: View {
           } label: {
             Text("TextField")
           }
+
+          NavigationLink {
+            InputFieldDetailView()
+          } label: {
+            Text("InputField")
+          }
         }
       }
       .navigationTitle("DesignSystem")

--- a/Projects/Shared/DesignSystem/Sources/Component/InputField/InputField.swift
+++ b/Projects/Shared/DesignSystem/Sources/Component/InputField/InputField.swift
@@ -1,0 +1,50 @@
+//
+//  InputField.swift
+//  DesignSystem
+//
+//  Created by 김지현 on 8/17/24.
+//  Copyright © 2024 PomoNyang. All rights reserved.
+//
+
+import SwiftUI
+
+public protocol InputFieldErrorProtocol {
+  var message: String { get }
+}
+
+public struct InputField<T: InputFieldErrorProtocol>: View {
+  var placeholder: String
+  @Binding var text: String
+  @Binding var fieldError: T?
+
+  public init(
+    placeholder: String,
+    text: Binding<String>,
+    fieldError: Binding<T?> = .constant(nil)
+  ) {
+    self.placeholder = placeholder
+    self._text = text
+    self._fieldError = fieldError
+  }
+
+  // MARK: Placeholder Color를 TextFieldStyle 내부에서 변경하는 방법 Plz...
+  public var body: some View {
+    VStack(spacing: Alias.Spacing.small) {
+      TextField(
+        placeholder,
+        text: $text,
+        prompt: Text(placeholder)
+          .foregroundStyle(Alias.Color.Text.disabled)
+      )
+      .textFieldStyle(.inputField($text, isError: fieldError != nil))
+
+      HStack {
+        Text(fieldError?.message ?? "")
+          .font(Typography.captionR)
+          .foregroundStyle(Alias.Color.Accent.red)
+        Spacer()
+      }
+      .padding(.horizontal, Alias.Spacing.xSmall)
+    }
+  }
+}

--- a/Projects/Shared/DesignSystem/Sources/Component/InputField/InputFieldStyle.swift
+++ b/Projects/Shared/DesignSystem/Sources/Component/InputField/InputFieldStyle.swift
@@ -32,7 +32,7 @@ struct InputFieldStyle: TextFieldStyle {
       )
       .focused($isFocused)
       .onChange(of: isFocused) {
-        if isFocused { isBorderShowed = true }
+        isBorderShowed = isFocused
       }
       .onChange(of: text) {
         isBorderShowed = false

--- a/Projects/Shared/DesignSystem/Sources/Component/InputField/InputFieldStyle.swift
+++ b/Projects/Shared/DesignSystem/Sources/Component/InputField/InputFieldStyle.swift
@@ -1,0 +1,51 @@
+//
+//  InputFieldStyle.swift
+//  DesignSystem
+//
+//  Created by 김지현 on 8/17/24.
+//  Copyright © 2024 PomoNyang. All rights reserved.
+//
+
+import SwiftUI
+// 빠진 것 : placeholder color
+struct InputFieldStyle: TextFieldStyle {
+  @State private var isBorderShowed: Bool = false
+  @FocusState private var isFocused: Bool
+  @Environment(\.isEnabled) private var isEnabled
+
+  @Binding var text: String
+  var isError: Bool
+
+  func _body(configuration: TextField<Self._Label>) -> some View {
+    configuration
+      .tint(Alias.Color.Accent.red)
+      .padding(.all, Alias.Spacing.large)
+      .frame(height: 56)
+      .frame(maxWidth: .infinity)
+      .font(Typography.bodySB)
+      .foregroundStyle(Alias.Color.Text.primary)
+      .background(Global.Color.white)
+      .cornerRadius(Alias.BorderRadius.small, corners: .allCorners)
+      .overlay(
+        RoundedRectangle(cornerRadius: Alias.BorderRadius.small)
+          .strokeBorder(getBorderColor(isBorderShowed: isBorderShowed || isError))
+      )
+      .focused($isFocused)
+      .onChange(of: isFocused) {
+        if isFocused { isBorderShowed = true }
+      }
+      .onChange(of: text) {
+        isBorderShowed = false
+      }
+  }
+
+  private func getBorderColor(isBorderShowed: Bool) -> Color {
+    return isBorderShowed ? Alias.Color.Accent.red : Color.clear
+  }
+}
+
+extension TextFieldStyle where Self == InputFieldStyle {
+  static func inputField(_ text: Binding<String>, isError: Bool) -> Self {
+    return InputFieldStyle(text: text, isError: isError)
+  }
+}


### PR DESCRIPTION
## [CAT-223] DesignSystem InputField

## 무엇에 관한 PR 인가요? 🙋
InputField

## Recorded View
https://github.com/user-attachments/assets/16379b10-d9a6-4515-89b6-a84ba7b2897b

## 어떤 것을 작업하셨나요? 🛠
- InputFieldStyle 구현
- InputField View 구현

## 🌱 PR Point
- 최대한 TextfieldStyle 내부에서 에러까지 하는 방법은 없을지 생각해보았는데, '에러가 딸려있으려면 textfield label 외부에 있어야하니까 View를 하나 만들어야겠다' 라는 생각까지만 도달했슴다 방법을 아신다면 help..
- InputField라는 View를 만들고, InputFieldErrorProtocol을 채택하는 error enum만 받기 위해 제너릭을 썼는데, 이것 또한 더 좋은 방법을 아신다면 help ...
- 민석 슨생님 처럼 깔끔하게 만들기 쉽지 않네요
