### PR TITLE
[CAT-299] 집중 시간 60분 선택시 0분으로 나오는 버그

### DIFF
--- a/Projects/Domain/PomodoroService/Interface/Model/PomodoroCategory.swift
+++ b/Projects/Domain/PomodoroService/Interface/Model/PomodoroCategory.swift
@@ -64,24 +64,24 @@ public struct PomodoroCategory: Persistable, Equatable, Identifiable, Codable {
 }
 
 extension PomodoroCategory {
-  public var focusTimeMinute: Int {
+  public var focusTimeMinutes: Int {
     let dateComponents = DateComponents.durationFrom8601String(focusTime)
-    return dateComponents?.minute ?? 0
+    return dateComponents?.totalMinutes ?? 0
   }
   
-  public var restTimeMinute: Int {
+  public var restTimeMinutes: Int {
     let dateComponents = DateComponents.durationFrom8601String(restTime)
-    return dateComponents?.minute ?? 0
+    return dateComponents?.totalMinutes ?? 0
   }
   
   public var focusTimeSeconds: Int {
     let dateComponents = DateComponents.durationFrom8601String(focusTime)
-    return (dateComponents?.minute ?? 0) * 60
+    return dateComponents?.totalSeconds ?? 0
   }
   
   public var restTimeSeconds: Int {
     let dateComponents = DateComponents.durationFrom8601String(restTime)
-    return (dateComponents?.minute ?? 0) * 60
+    return dateComponents?.totalSeconds ?? 0
   }
 }
 

--- a/Projects/Feature/HomeFeature/Sources/CategorySelect/CategorySelectView.swift
+++ b/Projects/Feature/HomeFeature/Sources/CategorySelect/CategorySelectView.swift
@@ -39,7 +39,7 @@ public struct CategorySelectView: View {
         ForEach(store.categoryList) { category in
           Button(
             title: .init(category.title),
-            subtitle: "집중 \(category.focusTimeMinute)분 | 휴식 \(category.restTimeMinute)분",
+            subtitle: "집중 \(category.focusTimeMinutes)분 | 휴식 \(category.restTimeMinutes)분",
             leftIcon: category.image
           ) {
             store.send(.selectCategory(category))

--- a/Projects/Feature/HomeFeature/Sources/Home/HomeCore.swift
+++ b/Projects/Feature/HomeFeature/Sources/Home/HomeCore.swift
@@ -296,8 +296,8 @@ public struct HomeCore {
     let restedTime = DateComponents(minute: restTimeBySeconds / 60, second: restTimeBySeconds % 60).to8601DurationString()
     let request = FocusTimeHistory(
       categoryNo: selectedCategoryID,
-      focusedTime: focusedTime,
-      restedTime: restedTime,
+      focusedTime: focusedTime ?? "PT0M",
+      restedTime: restedTime ?? "PT0M",
       doneAt: Date()
     )
     try await self.pomodoroService.saveFocusTimeHistory(

--- a/Projects/Feature/HomeFeature/Sources/Home/HomeView.swift
+++ b/Projects/Feature/HomeFeature/Sources/Home/HomeView.swift
@@ -64,7 +64,7 @@ public struct HomeView: View {
               Text("집중")
                 .font(Typography.bodySB)
                 .foregroundStyle(Global.Color.gray500)
-              Text("\(store.selectedCategory?.focusTimeMinute ?? 0)분")
+              Text("\(store.selectedCategory?.focusTimeMinutes ?? 0)분")
                 .font(Typography.header3)
                 .foregroundStyle(Alias.Color.Text.secondary)
             }
@@ -81,7 +81,7 @@ public struct HomeView: View {
               Text("휴식")
                 .font(Typography.bodySB)
                 .foregroundStyle(Global.Color.gray500)
-              Text("\(store.selectedCategory?.restTimeMinute ?? 0)분")
+              Text("\(store.selectedCategory?.restTimeMinutes ?? 0)분")
                 .font(Typography.header3)
                 .foregroundStyle(Alias.Color.Text.secondary)
             }

--- a/Projects/Feature/HomeFeature/Sources/TimeSelect/TimeSelectCore.swift
+++ b/Projects/Feature/HomeFeature/Sources/TimeSelect/TimeSelectCore.swift
@@ -83,9 +83,9 @@ public struct TimeSelectCore {
       if let category {
         switch state.mode {
         case .focus:
-          state.selectedTime = TimeItem(minute: category.focusTimeMinute)
+          state.selectedTime = TimeItem(minute: category.focusTimeMinutes)
         case .rest:
-          state.selectedTime = TimeItem(minute: category.restTimeMinute)
+          state.selectedTime = TimeItem(minute: category.restTimeMinutes)
         }
       } else {
         state.selectedTime = state.timeList.last

--- a/Projects/Feature/PomodoroFeature/Sources/FocusPomodoro/FocusPomodoroCore.swift
+++ b/Projects/Feature/PomodoroFeature/Sources/FocusPomodoro/FocusPomodoroCore.swift
@@ -138,7 +138,7 @@ public struct FocusPomodoroCore {
       
     case .setupFocusTime:
       guard let selectedCategory = state.selectedCategory else { return .none }
-      state.focusTimeBySeconds = selectedCategory.focusTimeMinute * 60
+      state.focusTimeBySeconds = selectedCategory.focusTimeSeconds
       return .none
       
     case .catSetInput:

--- a/Projects/Feature/PomodoroFeature/Sources/RestPomodoro/RestPomodoroCore.swift
+++ b/Projects/Feature/PomodoroFeature/Sources/RestPomodoro/RestPomodoroCore.swift
@@ -52,11 +52,11 @@ public struct RestPomodoroCore {
       )
     }
     var minus5MinuteButtonDisabled: Bool {
-      guard let restTimeMinute = selectedCategory?.restTimeMinute else { return false }
+      guard let restTimeMinute = selectedCategory?.restTimeMinutes else { return false }
       return restTimeMinute <= 5
     }
     var plus5MinuteButtonDisabled: Bool {
-      guard let restTimeMinute = selectedCategory?.restTimeMinute else { return false }
+      guard let restTimeMinute = selectedCategory?.restTimeMinutes else { return false }
       return restTimeMinute >= 30
     }
   }
@@ -163,7 +163,7 @@ public struct RestPomodoroCore {
       
     case .setupRestTime:
       guard let selectedCategory = state.selectedCategory else { return .none }
-      state.restTimeBySeconds = selectedCategory.restTimeMinute * 60
+      state.restTimeBySeconds = selectedCategory.restTimeSeconds
       return .none
       
     case .catTapped:
@@ -235,7 +235,7 @@ public struct RestPomodoroCore {
           state.changeRestTimeByMinute != 0
     else { return }
     
-    let changedTimeMinute = selectedCategory.restTimeMinute + state.changeRestTimeByMinute
+    let changedTimeMinute = selectedCategory.restTimeMinutes + state.changeRestTimeByMinute
     let iso8601Duration = DateComponents(minute: changedTimeMinute).to8601DurationString()
     let request = EditCategoryRequest(focusTime: nil, restTime: iso8601Duration)
     

--- a/Projects/Feature/PomodoroFeature/Sources/RestWaiting/RestWaitingCore.swift
+++ b/Projects/Feature/PomodoroFeature/Sources/RestWaiting/RestWaitingCore.swift
@@ -42,12 +42,12 @@ public struct RestWaitingCore {
     }
     
     var minus5MinuteButtonDisabled: Bool {
-      guard let focusTimeMinute = selectedCategory?.focusTimeMinute else { return false }
-      return focusTimeMinute <= 10
+      guard let focusTimeMinutes = selectedCategory?.focusTimeMinutes else { return false }
+      return focusTimeMinutes <= 10
     }
     var plus5MinuteButtonDisabled: Bool {
-      guard let focusTimeMinute = selectedCategory?.focusTimeMinute else { return false }
-      return focusTimeMinute >= 60
+      guard let focusTimeMinutes = selectedCategory?.focusTimeMinutes else { return false }
+      return focusTimeMinutes >= 60
     }
   }
   
@@ -170,7 +170,7 @@ public struct RestWaitingCore {
           state.changeFocusTimeByMinute != 0
     else { return }
     
-    let changedTimeMinute = selectedCategory.focusTimeMinute + state.changeFocusTimeByMinute
+    let changedTimeMinute = selectedCategory.focusTimeMinutes + state.changeFocusTimeByMinute
     let iso8601Duration = DateComponents(minute: changedTimeMinute).to8601DurationString()
     let request = EditCategoryRequest(focusTime: iso8601Duration, restTime: nil)
     

--- a/Projects/Shared/Utils/Sources/Extension/Foundation/DateComponents+iso8601Duration.swift
+++ b/Projects/Shared/Utils/Sources/Extension/Foundation/DateComponents+iso8601Duration.swift
@@ -1,0 +1,186 @@
+//
+//  DateComponents+iso8601Duration.swift
+//  Utils
+//
+//  Created by devMinseok on 8/23/24.
+//  Copyright © 2024 PomoNyang. All rights reserved.
+//
+
+import Foundation
+
+/*
+ * https://github.com/leonx98/Swift-ISO8601-DurationParser
+ * This extension converts ISO 8601 duration strings with the format: P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W into date components
+ * Examples:
+ * PT12H = 12 hours
+ * P3D = 3 days
+ * P3DT12H = 3 days, 12 hours
+ * P3Y6M4DT12H30M5S = 3 years, 6 months, 4 days, 12 hours, 30 minutes and 5 seconds
+ * P10W = 70 days
+ * For more information look here: http://en.wikipedia.org/wiki/ISO_8601#Durations
+ */
+extension DateComponents {
+  /// ISO8601 Duration -> DateComponents 
+  public static func durationFrom8601String(_ durationString: String) -> DateComponents? {
+    try? Self.from8601String(durationString)
+  }
+  
+  // Note: Does not handle fractional values for months
+  // Format: PnYnMnDTnHnMnS or PnW
+  static func from8601String(_ durationString: String) throws -> DateComponents {
+    guard durationString.starts(with: "P") else {
+      throw DurationParsingError.invalidFormat(durationString)
+    }
+    
+    let durationString = String(durationString.dropFirst())
+    var dateComponents = DateComponents()
+    
+    if let week = componentFor("W", in: durationString) {
+      // 7 day week specified in ISO 8601 standard
+      dateComponents.day = Int(week * 7.0)
+      return dateComponents
+    }
+    
+    let tRange = (durationString as NSString).range(of: "T", options: .literal)
+    let periodString: String
+    let timeString: String
+    if tRange.location == NSNotFound {
+      periodString = durationString
+      timeString = ""
+    } else {
+      periodString = (durationString as NSString).substring(to: tRange.location)
+      timeString = (durationString as NSString).substring(from: tRange.location + 1)
+    }
+    
+    // DnMnYn
+    let year = componentFor("Y", in: periodString)
+    let month = componentFor("M", in: periodString).addingFractionsFrom(year, multiplier: 12)
+    let day = componentFor("D", in: periodString)
+    
+    if let monthFraction = month?.truncatingRemainder(dividingBy: 1),
+       monthFraction != 0 {
+      // Representing fractional months isn't supported by DateComponents, so we don't allow it here
+      throw DurationParsingError.unsupportedFractionsForMonth(durationString)
+    }
+    
+    dateComponents.year = year?.nonFractionParts
+    dateComponents.month = month?.nonFractionParts
+    dateComponents.day = day?.nonFractionParts
+    
+    // SnMnHn
+    let hour = componentFor("H", in: timeString).addingFractionsFrom(day, multiplier: 24)
+    let minute = componentFor("M", in: timeString).addingFractionsFrom(hour, multiplier: 60)
+    let second = componentFor("S", in: timeString).addingFractionsFrom(minute, multiplier: 60)
+    dateComponents.hour = hour?.nonFractionParts
+    dateComponents.minute = minute?.nonFractionParts
+    dateComponents.second = second.map { Int($0.rounded()) }
+    
+    return dateComponents
+  }
+  
+  private static func componentFor(_ designator: String, in string: String) -> Double? {
+    // First split by the designator we're interested in, and then split by all separators. This should give us whatever's before our designator, but after the previous one.
+    let beforeDesignator = string.components(separatedBy: designator).first?.components(separatedBy: .separators).last
+    return beforeDesignator.flatMap { Double($0) }
+  }
+  
+  enum DurationParsingError: Error {
+    case invalidFormat(String)
+    case unsupportedFractionsForMonth(String)
+  }
+}
+
+extension Optional where Wrapped == Double {
+  func addingFractionsFrom(_ other: Double?, multiplier: Double) -> Self {
+    guard let other = other else { return self }
+    let toAdd = other.truncatingRemainder(dividingBy: 1) * multiplier
+    guard let self = self else { return toAdd }
+    return self + toAdd
+  }
+}
+
+extension Double {
+  var nonFractionParts: Int {
+    Int(floor(self))
+  }
+}
+
+extension CharacterSet {
+  static let separators = CharacterSet(charactersIn: "PWTYMDHMS")
+}
+
+extension DateComponents.DurationParsingError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .invalidFormat(let durationString):
+      return "\(durationString) has an invalid format, The durationString must have a format of PnYnMnDTnHnMnS or PnW"
+    case .unsupportedFractionsForMonth(let durationString):
+      return "\(durationString) has an invalid format, fractions aren't supported for the month-position"
+    }
+  }
+}
+
+extension DateComponents {
+  /// DateComponents -> ISO8601 Duration
+  public func to8601DurationString() -> String {
+    var durationString = "P"
+    
+    // 년, 월, 주, 일, 시간, 분, 초를 고려하여 변환
+    let totalSeconds = (self.second ?? 0)
+    + (self.minute ?? 0) * 60
+    + (self.hour ?? 0) * 3600
+    + (self.day ?? 0) * 86400
+    + (self.weekOfYear ?? 0) * 604800
+    + (self.month ?? 0) * 2629800 // 평균 월 길이 (30.44일)
+    + (self.year ?? 0) * 31557600 // 평균 년 길이 (365.25일)
+    
+    if totalSeconds == 0 {
+      return ""
+    }
+    
+    var remainingSeconds = totalSeconds
+    
+    let years = remainingSeconds / 31557600
+    remainingSeconds %= 31557600
+    let months = remainingSeconds / 2629800
+    remainingSeconds %= 2629800
+    let weeks = remainingSeconds / 604800
+    remainingSeconds %= 604800
+    let days = remainingSeconds / 86400
+    remainingSeconds %= 86400
+    let hours = remainingSeconds / 3600
+    remainingSeconds %= 3600
+    let minutes = remainingSeconds / 60
+    remainingSeconds %= 60
+    let seconds = remainingSeconds
+    
+    if years > 0 {
+      durationString += "\(years)Y"
+    }
+    
+    if months > 0 {
+      durationString += "\(months)M"
+    }
+    
+    if weeks > 0 {
+      durationString += "\(weeks)W"
+    } else if days > 0 {
+      durationString += "\(days)D"
+    }
+    
+    if hours > 0 || minutes > 0 || seconds > 0 {
+      durationString += "T"
+      if hours > 0 {
+        durationString += "\(hours)H"
+      }
+      if minutes > 0 {
+        durationString += "\(minutes)M"
+      }
+      if seconds > 0 {
+        durationString += "\(seconds)S"
+      }
+    }
+    
+    return durationString
+  }
+}

--- a/Projects/Shared/Utils/Sources/Extension/Foundation/DateComponents+iso8601Duration.swift
+++ b/Projects/Shared/Utils/Sources/Extension/Foundation/DateComponents+iso8601Duration.swift
@@ -20,7 +20,7 @@ import Foundation
  * For more information look here: http://en.wikipedia.org/wiki/ISO_8601#Durations
  */
 extension DateComponents {
-  /// ISO8601 Duration -> DateComponents 
+  /// ISO8601 Duration -> DateComponents
   public static func durationFrom8601String(_ durationString: String) -> DateComponents? {
     try? Self.from8601String(durationString)
   }
@@ -122,7 +122,7 @@ extension DateComponents.DurationParsingError: LocalizedError {
 
 extension DateComponents {
   /// DateComponents -> ISO8601 Duration
-  public func to8601DurationString() -> String {
+  public func to8601DurationString() -> String? {
     var durationString = "P"
     
     // 년, 월, 주, 일, 시간, 분, 초를 고려하여 변환
@@ -135,7 +135,7 @@ extension DateComponents {
     + (self.year ?? 0) * 31557600 // 평균 년 길이 (365.25일)
     
     if totalSeconds == 0 {
-      return ""
+      return nil
     }
     
     var remainingSeconds = totalSeconds


### PR DESCRIPTION
## 무엇에 관한 PR 인가요? 🙋
- 집중 시간 60분 선택시 0분으로 나오는 버그

## 어떤 것을 작업하셨나요? 🛠
- ISO8601 변환 메서드 개선
- DateComponents에서 total 시간을 가져올 수 있도록
- 집중시간 저장시 휴식시간이 없을때 PT0M으로 보내도록 (아니면 서버에러 발생함)